### PR TITLE
Update requirements.txt

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,6 +24,9 @@ Quick Start
 
 ``pip install google-alerts`` or ``python setup.py install``
 
+**Install all dependencies from requirements**:
+``pip install -r requirements.txt``
+
 **Save your configuration**:
 
 ``google-alerts setup --email <your.mail@foo.com> --password 'password'``

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,11 +5,11 @@ bs4==0.0.1
 certifi==2018.4.16
 chardet==3.0.4
 docutils==0.14
-google-alerts==0.1.8
+google-alerts>=0.1.8
 idna==2.6
 imagesize==1.0.0
 Jinja2>=2.10.1
-MarkupSafe==1.0
+MarkupSafe>=1.0
 packaging==17.1
 pkginfo==1.4.2
 Pygments==2.2.0


### PR DESCRIPTION
This update is required to run google-alerts smoothly. This can cause dependency conflicts, so the best practice is to install requirements.txt to the virtual environment 